### PR TITLE
Change how docker is installed on Linux2

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,4 +10,4 @@ rules:
   line-length: disable
   # NOTE(retr0h): Templates no longer fail this lint rule.
   #               Uncomment if running old Molecule templates.
-  # truthy: disable
+  truthy: disable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   when: ansible_kernel is not search("amzn2")
 
 - name: Install Docker with amazon-linux-extras
-  shell: "amazon-linux-extras install docker"
+  command: "amazon-linux-extras install docker"
   become: yes
   when: ansible_kernel is search("amzn2")
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,19 @@
     name:
       - python
       - python-setuptools
+    state: latest
+
+- name: Install Docker with Yum
+  package:
+    name:
       - docker
     state: latest
+  when: ansible_kernel is not search("amzn2")
+
+- name: Install Docker with amazon-linux-extras
+  shell: "amazon-linux-extras install docker"
+  become: yes
+  when: ansible_kernel is search("amzn2")
 
 - name: Install Pip
   easy_install:


### PR DESCRIPTION
docker is now part of the Amazon extra packages so we need
to install it using amazon-linux-extras.

see https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras